### PR TITLE
Remove OSS repository type from .autorelease.yml

### DIFF
--- a/.autorelease.yml
+++ b/.autorelease.yml
@@ -1,8 +1,6 @@
 type: local
 local:
-  repositoryType: oss
   releaseStrategy:
     type: timeBasedRelease
     timeBasedRelease:
       timeSinceLastRelease: 4 days
-


### PR DESCRIPTION
Makes it so that repository is treated as a Go repository rather than an OSS one.

## Before this PR
The autorelease-bot creates releases that do not use a 'v' prefix, which is invalid because Go modules require this prefix and Go repository automation assumes it will exist.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Removes the "repositoryType" configuration from the .autorelease.yml file so that the repository type will be inferred.
==COMMIT_MSG==

## Possible downsides?
I'm not entirely sure why "oss" is its own repository type to begin with -- looking at the implementation, it looks like the only real difference is whether the minor or patch version is incremented for certain releases. However, all our other OSS Go projects work, so don't think it should be necessary.

There's also a small chance that the repository type must be specified if a configuration file exists. If that is the case, then the PR should be modified to specify the repository type to be a go module type ("gomodule") rather than OSS.
