### PR TITLE
fix: Remove '.' from sanitized type names

### DIFF
--- a/changelog/@unreleased/pr-105.v2.yml
+++ b/changelog/@unreleased/pr-105.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove '.' from sanitized type names
+  links:
+  - https://github.com/palantir/godel-refreshables-plugin/pull/105

--- a/plugin/generator/utils.go
+++ b/plugin/generator/utils.go
@@ -58,7 +58,9 @@ func longestCommonPkgPathSuffix(pkgA []string, pkgB []string) int {
 }
 
 func sanitizePackageAlias(alias string) string {
-	return strings.ReplaceAll(alias, "-", "")
+	alias = strings.ReplaceAll(alias, ".", "")
+	alias = strings.ReplaceAll(alias, "-", "")
+	return alias
 }
 
 // refreshableLibraryImpl returns the library implementations for the type and constructor if they exist.


### PR DESCRIPTION
## Before this PR
Types fail when they include `.` in their import path (e.g. `gopkg.in/inf.v0`) and require namespacing due to a similarly named type in a different package.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove '.' from sanitized type names
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

