### PR TITLE
Add package write permissions to publish dists

### DIFF
--- a/.github/workflows/publish-godel-artifacts.yml
+++ b/.github/workflows/publish-godel-artifacts.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   run-godel-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       #####################


### PR DESCRIPTION
## Before this PR
Actions have been failing to publish since the default permissions have been changed to read only

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add package write permissions to publish dists
==COMMIT_MSG==

This is based on the following GH docs: https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

