### PR TITLE
Add contents write permission to publish dists to GH

### DIFF
--- a/.github/workflows/publish-godel-artifacts.yml
+++ b/.github/workflows/publish-godel-artifacts.yml
@@ -7,8 +7,7 @@ jobs:
   run-godel-publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: write
     steps:
       - uses: actions/checkout@v2
       #####################


### PR DESCRIPTION
## Before this PR
The previous attempt (https://github.com/palantir/godel-refreshables-plugin/runs/6885694450?check_suite_focus=true) at this did not succeed since we did not have the correct contents permissions.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add contents write permission to publish dists to GH
==COMMIT_MSG==

We use the [create a release](https://docs.github.com/en/rest/releases/releases#create-a-release) endpoint (i.e. `POST /repos/:owner/:repo/releases`) on GH to publish a new release. The permissions for this endpoint require `contents: write` in order to be able to publish correctly. You can find the docs for this on the GH rest API [permission overview](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-contents)

I did a test run with this change by adding this branch as an allowed branch to run the action, which was succesful.
https://github.com/palantir/godel-refreshables-plugin/runs/6886563269?check_suite_focus=true

Once this merges and a release is successfully cut, I will update the excavator that writes this workflow to include the correct permissions.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

