### PR TITLE
Delete .palantir/autorelease.yml

### DIFF
--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,4 +1,0 @@
-version: 3
-schedules:
-  timer:
-    time_since_last_release: 4 days


### PR DESCRIPTION
Other repositories generally don't use this, and the refreshables plugin isn't that special.