### PR TITLE
Remove autorelease configuration file

### DIFF
--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,4 +1,0 @@
-version: 3
-schedules:
-  timer:
-    time_since_last_release: 4 days


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make it so that plugin no longer automatically releases on a weekly cadence. Releasing godel plugins and assets on a time-based schedule produces more churn than necessary and it is not as important to release after every dependency update as it is for services.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

